### PR TITLE
Add allowEncodedSlash to http & https

### DIFF
--- a/docker/config/traefik/traefik.yml
+++ b/docker/config/traefik/traefik.yml
@@ -16,13 +16,18 @@ global:
 entryPoints:
   web:
     address: ":80"
+    http:
+      encodedCharacters:
+        allowEncodedSlash: true
   
   db:
     address: ":90"
 
   websecure:
     address: ":443"
-
+    http:
+      encodedCharacters:
+        allowEncodedSlash: true
   ssh:
     address: ":22"
 


### PR DESCRIPTION
## Description

Allow encoded slah in the urls of the containers mainteained by traefik